### PR TITLE
Feature/calculate second

### DIFF
--- a/src/components/CalculateSecond/CalculateRateBox.js
+++ b/src/components/CalculateSecond/CalculateRateBox.js
@@ -1,24 +1,45 @@
-import React from "react";
+import React, { useEffect, useState } from "react";
 import "./CalculateRateBox.css";
 
-const CalculateRateBox = () => {
+const CalculateRateBox = ({currentExchangedMoney, currentQuotes, currentTimeStamp}) => {
   const rateList = ["CAD", "KRW", "HKD", "JPY", "CNY"];
-  const test = "CAD";
-  const money = "20,000.00";
+  const [currentActiveCurrency, setCurrentActiveCurrency] = useState('CAD');
+  const [currentMoney, setCurrentMoney] = useState(0);
+  
+  const checkCurrentActiveTab = event => {
+    const currentClickedTab = event.target.dataset.rate;
+    
+    for(let [key, val] of Object.entries(currentQuotes)) {
+      const currentCurrency = key.slice(3, key.length);
+
+      if(currentCurrency === currentClickedTab) {
+        setCurrentActiveCurrency(currentCurrency);
+        setCurrentMoney(val * Number(currentExchangedMoney));
+      };
+    }
+  }
+ 
+  useEffect(() => {
+    if(currentActiveCurrency === 'CAD') {
+      const currentQuote = !currentQuotes['USDCAD'] ? 0 : currentQuotes['USDCAD'];
+      console.log(currentQuote);
+      setCurrentMoney(currentQuote * Number(currentExchangedMoney))
+    }
+  }, [currentExchangedMoney])
 
   return (
     <div className="CalculateRateBox">
-      <ul className="tabs">
+      <ul className="tabs" onClick={checkCurrentActiveTab}>
         {rateList.map((rate, index) => {
           return (
-            <li className={`tab ${rate === test && "active"}`} key={index}>
+            <li data-rate={rate} className={`tab ${rate === currentActiveCurrency && "active"}`} key={index}>
               {rate}
             </li>
           );
         })}
       </ul>
       <div className="tabsInfo">
-        <p className="countryRate">{`${test} : ${money}`} </p>
+        <p className="countryRate">{`${currentActiveCurrency} : ${currentMoney}`} </p>
         <p className="rateLiveDate">
           기준일: <br /> 2022-Jan-01
         </p>

--- a/src/components/CalculateSecond/CalculateRateBox.js
+++ b/src/components/CalculateSecond/CalculateRateBox.js
@@ -1,11 +1,23 @@
-import React, { useEffect, useState } from "react";
+import React, { useLayoutEffect, useState } from "react";
 import "./CalculateRateBox.css";
+import {setMonthConvert} from '../../utils/setMonthConvert';
 
-const CalculateRateBox = ({currentExchangedMoney, currentQuotes, currentTimeStamp}) => {
-  const rateList = ["CAD", "KRW", "HKD", "JPY", "CNY"];
+const CalculateRateBox = ({currentExchangedMoney, currentQuotes, currentTimeStamp, currentSelectedCurrency}) => {
+  const [rateList, setRateList] = useState(["CAD", "KRW", "HKD", "JPY", "CNY"]);
   const [currentActiveCurrency, setCurrentActiveCurrency] = useState('CAD');
   const [currentMoney, setCurrentMoney] = useState(0);
   
+  const createDate = () => {
+    
+    const date = new Date(currentTimeStamp * 1000);
+    
+    const years = date.getFullYear();
+    const month = setMonthConvert(date.getMonth());
+    const day = date.getDay();
+
+    return `${years} ${month} ${day}`
+  }
+
   const checkCurrentActiveTab = event => {
     const currentClickedTab = event.target.dataset.rate;
     
@@ -18,15 +30,30 @@ const CalculateRateBox = ({currentExchangedMoney, currentQuotes, currentTimeStam
       };
     }
   }
- 
-  useEffect(() => {
+
+  useLayoutEffect(() => {
+    if(currentSelectedCurrency === 'CAD') {
+      const newRateList = [...rateList];
+      newRateList[0] = 'USD';
+      
+      setRateList(newRateList);
+      setCurrentActiveCurrency('USD');
+    } else if(currentSelectedCurrency === 'USD') {
+      const newRateList = [...rateList];
+      newRateList[0] = 'CAD';
+      
+      setRateList(newRateList);
+      setCurrentActiveCurrency('CAD');
+    }
+
     if(currentActiveCurrency === 'CAD') {
       const currentQuote = !currentQuotes['USDCAD'] ? 0 : currentQuotes['USDCAD'];
-      console.log(currentQuote);
+      
       setCurrentMoney(currentQuote * Number(currentExchangedMoney))
     }
-  }, [currentExchangedMoney])
 
+  }, [currentExchangedMoney, currentSelectedCurrency])
+  
   return (
     <div className="CalculateRateBox">
       <ul className="tabs" onClick={checkCurrentActiveTab}>
@@ -38,12 +65,16 @@ const CalculateRateBox = ({currentExchangedMoney, currentQuotes, currentTimeStam
           );
         })}
       </ul>
-      <div className="tabsInfo">
+      {
+        currentExchangedMoney.length < 5 || !currentExchangedMoney ? (
+          <div className="tabsInfo">
         <p className="countryRate">{`${currentActiveCurrency} : ${currentMoney}`} </p>
         <p className="rateLiveDate">
-          기준일: <br /> 2022-Jan-01
+          기준일: <br /> {currentTimeStamp && createDate()}
         </p>
       </div>
+        ) : <p className="alertMessage">송금액이 바르지 않습니다</p>
+      }
     </div>
   );
 };

--- a/src/components/CalculateSecond/CalculateSecondForm.js
+++ b/src/components/CalculateSecond/CalculateSecondForm.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import CalculateRateBox from "./CalculateRateBox.js";
 import "./CalculateSecondForm.css";
 import client from "../../pages/Main/lib/api/client";
@@ -6,7 +6,7 @@ import client from "../../pages/Main/lib/api/client";
 const CalculateSecondForm = () => {
   const [countryRates, setCountryRates] = useState(["USD", "CAD", "KRW", "HKD", "JPY", "CNY"]);
   const [currentQuotes, setCurrentQuotes] = useState({});
-  const [currentTimeStamp, setCurrentTimeStamp] = useState(0);
+  const [currentTimeStamp, setCurrentTimeStamp] = useState(null);
   const [currentExchangedMoney, setCurrentExchangedMoney] = useState(0);
   const [currentSelectedCurrency, setCurrentSelectedCurrency] = useState("USD");
 
@@ -55,6 +55,20 @@ const CalculateSecondForm = () => {
     }
   };
 
+  useEffect(() => {
+    const getCurrentCurrencies = async () => {
+      const expectedCurrencies = exceptSelectedCurrencies(currentSelectedCurrency);
+
+      const response = await getExchangedMoney(currentExchangedMoney, 'USD', expectedCurrencies);
+      const { data: {quotes, timestamp} } = response;
+
+      setCurrentQuotes({...currentQuotes, ...quotes});
+      setCurrentTimeStamp(timestamp);
+    }
+
+    getCurrentCurrencies();
+  }, []);
+  
   return (
     <div className="calculateSecondForm">
       <div className="controllerHeader" onChange={checkInputedController}>
@@ -69,7 +83,7 @@ const CalculateSecondForm = () => {
           })}
         </select>
       </div>
-      <CalculateRateBox currentExchangedMoney={currentExchangedMoney} currentQuotes={currentQuotes} currentTimeStamp={currentTimeStamp}/>
+      <CalculateRateBox currentExchangedMoney={currentExchangedMoney} currentQuotes={currentQuotes} currentTimeStamp={currentTimeStamp} currentSelectedCurrency={currentSelectedCurrency}/>
     </div>
   );
 };

--- a/src/utils/setMonthConvert.js
+++ b/src/utils/setMonthConvert.js
@@ -1,0 +1,7 @@
+export const setMonthConvert = (month) => {
+    const monthNames = ["Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"
+    ];
+
+    return monthNames[month];
+}


### PR DESCRIPTION
## :: 최근 작업 주제 (하나 이상의 주제를 선택해주세요.)
- [x] 기능 추가
- [] 리뷰 반영
- [] 리팩토링
- [ ] 버그 수정
- [ ] 컨벤션 수정

<br />

## :: 구현 목표
- 송금 국가에 따라 각기 다른 환율 비율 서버에서 가져오기
- 현재 탭 선택되어진 국가의 환율 계산 및 UI 동적 랜더링
- USD 탭이 선택되어진 경우와 CAD 탭이 선택되어진 경우에 따라 동적 랜더링

<br />

## :: 구현 사항 설명
1. 선택되어진 송금 국가를 API 통신을 할 경우, source key 값에 할당하여 quotes와 timestamp data값을 가져 와 화면에 동적 랜더링
2. 현재 선택되어진 국가일 경우에는 해당 탭의 border-bottom 값을 none으로 추가 스타일 값을 주어 UI 동적 랜더링
3. 부모 컴포넌트에서 현재 선택되어져 있는 국가 환율 이름 값을 자식 컴포넌트 calculateBox에 props로 넘겨 주어 만약 해당 국가 환율 이름이 USD이나 CAD일 경우에는 탭에서 제외되도록 컴포넌트 업데이트 및 마운트 시에 결정

<br />

## :: 성장 포인트
- new Date를 통해 날짜 인스턴스를 생성하고 해당 인스턴스를 통해 년 월 일를 가져오는 연습을 할 수 있었다. 또한 배열 내에서 일부 요소만을 수정하고 싶을 경우에 원본 배열을 복사한 뒤에 해당 복사본 객체의 인덱스로 요소에 접근하여 값을 바꾸는 방법을 학습할 수 있었다.
<br />

## :: 기타 질문 및 특이 사항
